### PR TITLE
Add admin

### DIFF
--- a/app/assets/stylesheets/admin_sessions.scss
+++ b/app/assets/stylesheets/admin_sessions.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the admin_sessions controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/admin_sessions_controller.rb
+++ b/app/controllers/admin_sessions_controller.rb
@@ -1,0 +1,19 @@
+class AdminSessionsController < ApplicationController
+  def new; end
+
+  def create
+    @admin = Admin.find_by(email: params[:email])
+
+    if @admin.present? && @admin.authenticate(params[:password])
+      session[:admin_id] = @admin.id
+      redirect_to admins_path, notice: 'Logged in successfully'
+    else
+      redirect_to admins_sign_in_path, alert: 'Invalid email or password'
+    end
+  end
+
+  def destroy
+    session[:admin_id] = nil
+    redirect_to admins_path, notice: 'Admin logged out'
+  end
+end

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -1,0 +1,26 @@
+class AdminsController < ApplicationController
+  before_action :redirect
+  def index
+    @admins = Admin.all
+    @brokers = Broker.all
+    @buyers = Buyer.all
+  end
+
+  def new; end
+
+  def create
+    @admin = Admin.new(admin_register_params)
+
+    if @admin.save
+      redirect_to admins_path, notice: 'Successfully created new Admin!'
+    else
+      redirect_to admins_new_path, alert: @admin.errors.full_messages.first
+    end
+  end
+
+  protected
+
+  def redirect
+    redirect_to admins_sign_in_path unless admin_logged_in?
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,20 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   devise_group :user, contains: %i[buyer broker]
+  helper_method :current_admin
+  helper_method :admin_logged_in?
 
   protected
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:type])
+  end
+
+  def current_admin
+    Admin.find_by(id: session[:admin_id])
+  end
+
+  def admin_logged_in?
+    !current_admin.nil?
   end
 end

--- a/app/helpers/admin_sessions_helper.rb
+++ b/app/helpers/admin_sessions_helper.rb
@@ -1,0 +1,2 @@
+module AdminSessionsHelper
+end

--- a/app/helpers/admins_helper.rb
+++ b/app/helpers/admins_helper.rb
@@ -1,0 +1,2 @@
+module AdminsHelper
+end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,0 +1,6 @@
+class Admin < ApplicationRecord
+  has_secure_password
+  validates :email, presence: true, uniqueness: true, format: { with: /\A[^@\s]+@[^@\s]+\z/, message: 'must be a valid email address' }
+  validates :password, presence: true
+  validates :password_confirmation, presence: true
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,17 @@ Rails.application.routes.draw do
 
   # get 'home/index'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+
+
+  # get "/sign_up" => "registrations#new"
+  # post "/admins" => "registrations#create"
+  get "/admins/new" => "admins#new"
+  post "/admins" => "admins#create"
+  get "/admins/sign_in" => "admin_sessions#new"
+  post "/admins/sign_in" => "admin_sessions#create"
+  delete "/logout" => "admin_sessions#destroy"
+  get "/redirect" => "admin_sessions#redirect"
+
+  get "/admins/new_broker" => "admins#new_broker"
+  post "/admins/new_broker" => "admins#create_broker"
 end

--- a/db/migrate/20210618080832_create_admins.rb
+++ b/db/migrate/20210618080832_create_admins.rb
@@ -1,0 +1,11 @@
+class CreateAdmins < ActiveRecord::Migration[6.0]
+  def change
+    create_table :admins do |t|
+      t.string :email, null: false
+      t.string :password_digest, null: false
+      t.timestamps
+    end
+
+    add_index :admins, :email, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_18_052708) do
+ActiveRecord::Schema.define(version: 2021_06_18_080832) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "admins", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "password_digest", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["email"], name: "index_admins_on_email", unique: true
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false


### PR DESCRIPTION
This PR is for generating the admin model, admin_sessions controller and admins controller. The admin model also has added validations for each column. The admin model uses has_secure_password from the gem bcrypt and email being unique. The admin_sessions controller has two methods (:new, :create and :destroy) that creates the log in and log out for admins. The admins controller has four methods (:index, :new, :create and :redirect). As of now, the index shows all the users and admins in the database, the new and create methods enables the current admin to create another admin, and the redirect method redirects the user to the login page if the user is not logged in. For now, the first admin account will be created using the console.