### PR TITLE
Rspec test user

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--format documentation

--- a/app/models/broker_stock.rb
+++ b/app/models/broker_stock.rb
@@ -1,3 +1,6 @@
 class BrokerStock < ApplicationRecord
   belongs_to :broker
+
+  validates :symbol, presence: true
+  validates :company_name, presence: true
 end

--- a/app/models/buyer_stock.rb
+++ b/app/models/buyer_stock.rb
@@ -1,3 +1,6 @@
 class BuyerStock < ApplicationRecord
   belongs_to :buyer
+
+  validates :symbol, presence: true
+  validates :company_name, presence: true
 end

--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -1,3 +1,4 @@
 class Stock < ApplicationRecord
   validates :symbol, presence: true
+  validates :company_name, presence: true
 end

--- a/spec/models/admin_spec.rb
+++ b/spec/models/admin_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Admin, type: :model do
+  let!(:admin) { described_class.create(email: 'e@email.com', password: 'password', password_confirmation: 'password') }
+
+  context 'with validation tests' do
+    it 'ensures email presence' do
+      admin.email = nil
+
+      expect(admin).not_to be_valid
+    end
+
+    it 'ensures password presence' do
+      admin.password = nil
+
+      expect(admin).not_to be_valid
+    end
+
+    it 'ensures password_confirmation presence' do
+      admin.password_confirmation = nil
+
+      expect(admin).not_to be_valid
+    end
+
+    it 'must successfully save' do
+      expect(admin).to be_valid
+    end
+  end
+end

--- a/spec/models/broker_spec.rb
+++ b/spec/models/broker_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Broker, type: :model do
+  let!(:broker) { described_class.create(email: 'e@email.com', password: 'password', password_confirmation: 'password') }
+
+  context 'with validation tests' do
+    it 'ensures email presence' do
+      broker.email = nil
+
+      expect(broker).not_to be_valid
+    end
+
+    it 'ensures password presence' do
+      broker.password = nil
+
+      expect(broker).not_to be_valid
+    end
+
+    it 'ensures password_confirmation presence' do
+      broker.password_confirmation = nil
+
+      expect(broker).not_to be_valid
+    end
+
+    it 'must successfully save' do
+      expect(broker).to be_valid
+    end
+  end
+end

--- a/spec/models/broker_stock_spec.rb
+++ b/spec/models/broker_stock_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe BrokerStock, type: :model do
+  let!(:broker) { Broker.create(email: 'e@email.com', password: 'password', password_confirmation: 'password') }
+  let(:broker_stock) { broker.broker_stocks.build(symbol: 'MC', price: 260.76, company_name: 'Microsoft Corp') }
+
+  context 'with validations/stock should fail to save' do
+    it 'is not valid without symbol' do
+      broker_stock.symbol = 'MC'
+
+      expect(broker_stock).to be_valid
+    end
+
+    it 'is not valid without a company_name' do
+      broker_stock.company_name = nil
+
+      expect(broker_stock).not_to be_valid
+    end
+  end
+end

--- a/spec/models/buyer_stock_spec.rb
+++ b/spec/models/buyer_stock_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe BuyerStock, type: :model do
+  let!(:buyer) { Buyer.create(email: 'e@email.com', password: 'password', password_confirmation: 'password') }
+  let(:buyer_stock) { buyer.buyer_stocks.build(symbol: 'MC', price: 260.76, company_name: 'Microsoft Corp') }
+
+  context 'with validations/stock should fail to save' do
+    it 'is not valid without symbol' do
+      buyer_stock.symbol = 'MC'
+
+      expect(buyer_stock).to be_valid
+    end
+
+    it 'is not valid without a company_name' do
+      buyer_stock.company_name = nil
+
+      expect(buyer_stock).not_to be_valid
+    end
+  end
+end

--- a/spec/models/stock_spec.rb
+++ b/spec/models/stock_spec.rb
@@ -1,16 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe Stock, type: :model do
-  let!(:stock) { described_class.new }
+  let!(:stock) { described_class.create(symbol: 'MC', price: 260.76, company_name: 'Microsoft Corp') }
 
   context 'with validations/stock should fail to save' do
     it 'is not valid without symbol' do
       stock.symbol = nil
-      stock.price = 260.76
-      stock.company_name = 'Microsoft Corp'
-      stock.save
 
-      expect(stock.errors.to_h.keys).to include(:symbol)
+      expect(stock).not_to be_valid
+    end
+
+    it 'is not valid without a company_name' do
+      stock.company_name = nil
+
+      expect(stock).not_to be_valid
     end
   end
 end


### PR DESCRIPTION
In this PR, we started by adding --format documentation to .rspec, this format is used so that we can easily manage and check the errors. We use rspec testing to test our models of buyers, brokers, admins, stock, broker_stock, and buyer_stock.