### PR TITLE
Add transaction to admin

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -1,9 +1,7 @@
 class AdminsController < ApplicationController
   before_action :redirect
   def index
-    @admins = Admin.all
-    @brokers = Broker.where(approved: true)
-    @buyers = Buyer.all
+    @users = User.where(approved: true)
   end
 
   def new

--- a/app/controllers/user_transactions_controller.rb
+++ b/app/controllers/user_transactions_controller.rb
@@ -1,10 +1,12 @@
 class UserTransactionsController < ApplicationController
-  before_action :authenticate_user!
+  # before_action :authenticate_user!
   def index
     if buyer_signed_in?
       @transactions = current_buyer.user_transactions.order(updated_at: :desc)
     elsif broker_signed_in?
       @broker_transactions = current_broker.broker_stocks.map(&:user_transactions)
+    elsif admin_logged_in?
+      @transactions = UserTransaction.order(updated_at: :desc)
     end
   end
 end

--- a/app/views/admins/index.html.erb
+++ b/app/views/admins/index.html.erb
@@ -1,6 +1,6 @@
 <section class="admin-table">
   <table class="admin-content-table">
-    <Caption>All Buyers</Caption>
+    <Caption>All Users</Caption>
 
     <thead>
       <tr>
@@ -8,42 +8,22 @@
         <th>First Name</th>
         <th>Last Name</th>
         <th>Username</th>
+        <th>Action</th>
       </tr>
     </thead>
 
     <tbody>
-      <% @buyers.each do |buyer|%>
+      <% @users.each do |user|%>
         <tr>
-          <td><%= buyer.email%></td>
-          <td><%= buyer.first_name%></td>
-          <td><%= buyer.last_name%></td>
-          <td><%= buyer.username%></td>
+          <td><%= user.email%></td>
+          <td><%= user.first_name%></td>
+          <td><%= user.last_name%></td>
+          <td><%= user.username%></td>
+          <%if user.type == 'Broker'%>
+          <td><%= link_to 'Edit', edit_admin_broker_path(current_admin, user)%></td>
+          <%end%>
         </tr>
       <%end%>
     </tbody>
   </table>
-
-  <table class="admin-content-table">
-    <Caption>All Brokers</Caption>
-
-    <thead>
-      <th>Email</th>
-      <th>First Name</th>
-      <th>Last Name</th>
-      <th>Username</th>
-    </thead>
-
-    <tbody>
-      <% @brokers.each do |broker|%>
-        <tr>
-          <td><%= broker.email %></td>
-          <td><%= broker.first_name%></td>
-          <td><%= broker.last_name%></td>
-          <td><%= broker.username%></td>
-        </tr>
-      <%end%>
-    </tbody>
-
-  </table>
-
 </section>

--- a/app/views/shared/_nav_bar.html.erb
+++ b/app/views/shared/_nav_bar.html.erb
@@ -93,6 +93,13 @@
       <li class="list">
         <%= link_to "Pending Brokers", admin_brokers_path(current_admin)%>
       </li>
+
+      <li class="list">
+        <%= link_to user_transactions_path do %>
+          <span>Transactions</span>
+        <% end %>
+      </li>
+
       <li class="list">
         <%= link_to "Logout", logout_path(current_admin), method: :delete%>
       </li>

--- a/app/views/user_transactions/index.html.erb
+++ b/app/views/user_transactions/index.html.erb
@@ -45,6 +45,21 @@
             </tr>
           <%end%>
         <%end%>
+      <%elsif admin_logged_in?%>
+        <% @transactions.each do |transaction|%>
+          <tr>
+            <td><%= transaction.buyer.email%></td>
+            <td><%= transaction.broker_stock.symbol%></td>
+            <td><%= transaction.broker_stock.broker.email%></td>
+            <td><%= transaction.quantity%></td>
+            <%unless transaction.total_price.nil?%>
+              <td><%= transaction.total_price.ceil(2)%></td>
+              <%else%>
+                <td><%= transaction.total_price%></td>
+            <%end%>
+            <td><%= transaction.created_at.strftime('%B %d, %Y')%></td>
+          </tr>
+        <%end%>
       <%end%>
     </tbody>
   </table>


### PR DESCRIPTION
This PR is mainly for adding a transaction page between all users to admin. The Users page was also modified so that instead of showing the list of buyers and brokers in different tables, all the buyers and brokers will be in a single table. The navigation bar was also modified to show a link of the transaction page for the admin.

### All Users page
![users-admin](https://user-images.githubusercontent.com/76772310/124243485-83cc4100-db50-11eb-80fd-04762f2ebcb6.png)

### Transaction page
![transaction-admin](https://user-images.githubusercontent.com/76772310/124243841-e291ba80-db50-11eb-80b7-02d3058b1966.png)

