### PR TITLE
add action mailer url to production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -110,6 +110,7 @@ Rails.application.configure do
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
-  # config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  # Mailer for Devise in Heroku app
+  config.action_mailer.default_url_options = { host: 'stockpile-eli-leif.herokuapp.com' }
 
 end


### PR DESCRIPTION
This PR is for adding an action_mailer_url_option to production.rb to enable the app to send an email message upon sign-up of broker and buyer.